### PR TITLE
add color swap function and option

### DIFF
--- a/MARQUEE.md
+++ b/MARQUEE.md
@@ -63,6 +63,7 @@ mymarquee = ezFBmarquee(device, fontName,
                         mode='marquee',
                         pad=0.33, pause=0, hgap=0,
                         fg=1, bg=0,
+                        cswap = False,
                         verbose=False)
 ```
 Required Arguments:
@@ -88,6 +89,8 @@ Optional Arguments:
 * *fg*, *bg*: (integers) : foreground and background colors.
   * Foreground will default to 1; for color displays this needs to be set appropriately.
   * The marquee cannot be displayed transparently the box will always fully overwrite the specified area.
+* *cswap*: (bool) : Swap bytes in 16-bit color word.
+  * Default False; only needs to be set True for RGB displays with reversed byte order (eg st7789).
 * *verbose*: (bool) : enables verbose feedback on init, start, pause and stop.
 
 ### Methods:

--- a/WRITER.md
+++ b/WRITER.md
@@ -40,7 +40,10 @@ You then create a font instance for each imported font:
 ```python
 myfont = ezFBfont(device, fontName,
                   fg=1, bg=0 ,tkey=-1,
-                  halign='left', valign='top', hgap=0, vgap=0,
+                  halign='left', valign='top',
+                  hgap=0, vgap=0,
+                  split='\n'
+                  cswap=False,
                   verbose=False)
 ```
 Required Arguments:
@@ -62,7 +65,9 @@ Optional Arguments:
   * Defaults to `0`, and is only applied between individual characters and between lines, negative values are allowed.
   * This is a gap, not padding; no background is drawn in the spaces created by positive values.
   * Negative values are allowed, if using them you should also use a transparent background (`tkey=0`) to stop character backgrounds 'clipping' the previous characters as they are drawn.
-* *split*: (chr/string) : the character(s) to split multi-line strings on, defaults to '\n' (0xA).
+* *split*: (chr/string) : the character(s) to split multi-line strings on, defaults to '\n' (0x0A).
+* *cswap*: (bool) : Swap bytes in 16-bit color word.
+  * Default False; only needs to be set True for RGB displays with reversed byte order (eg st7789).
 * *verbose*: (bool) : Enables verbose feedback on init, default changes and missing characters, default `False`.
 
 ### Methods:


### PR DESCRIPTION
Color operation works; but the ST7789 TFT display series (and, presumably, others) uses a LSB byte order for it's 16-bit color words. See #26

This adds a `cswap = (bool)` init argument (default `False`) that wil apply the byte swap when preparing the 'blit palette' used when characters are written.